### PR TITLE
Avoid `requirements_dev.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ which are discrete versions of the corresponding dynamics equations - either ord
    pip install --editable .
    ```
 
-   In the unlikely case that this installation of the package without dedicated dependency-version numbers fails, install the dependencies directly:
-
-   ```bash
-   pip install -r requirements_dev.txt
-   ```
-
 3. Run your first script, e.g.
 
    ```bash


### PR DESCRIPTION
I propose to remove instructions on `requirements_dev.txt`.
We as developers have to take care that the package installation takes care of the dependencies. Let's talk about it, to understand which measures are in place.

I would encourage us to even remove the file `requriments_dev.txt`.