### PR TITLE
Unit test phmbs: Avoid "if"

### DIFF
--- a/test/test_compare_phmbs_with_metis.py
+++ b/test/test_compare_phmbs_with_metis.py
@@ -34,7 +34,7 @@ class TestCompareWithMetis:
 
         manager = pydykit.Manager(content_config_file=content_config_file)
 
-        manager.system.initialize()  # creates MBS named FourParticleSystem
+        manager.system.initialize()
 
         # intermediate steps if conversion to PH system is necessary
         porthamiltonian_system = pydykit.systems.PortHamiltonianMBS(manager=manager)

--- a/test/test_compare_with_metis.py
+++ b/test/test_compare_with_metis.py
@@ -21,10 +21,6 @@ example_worklist = [
         name="four_particle_system",
         result_indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
     ),
-    dict(
-        name="four_particle_system_port_hamiltonian",
-        result_indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-    ),
 ]
 
 
@@ -46,16 +42,7 @@ class TestCompareWithMetis:
 
         manager = pydykit.Manager(content_config_file=content_config_file)
 
-        manager.system.initialize()  # creates MBS named FourParticleSystem
-
-        if isinstance(
-            manager.integrator, pydykit.integrators.PortHamiltonianIntegrator
-        ):
-            # intermediate steps if conversion to PH system is necessary
-            porthamiltonian_system = pydykit.systems.PortHamiltonianMBS(manager=manager)
-            porthamiltonian_system.initialize(MultiBodySystem=manager.system)
-            # creates an instance of PHS with attribute MBS
-            manager.system = porthamiltonian_system
+        manager.system.initialize()
 
         result = manager.manage()
 


### PR DESCRIPTION
I created a new test for the case where port hamiltonian MBS are derived from standard MBS.
This avoids an if-clause.