### PR TITLE
Add dostring for ExampleManager class

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,10 @@ extra:
     provider: mike # TODO: Check this when deployed
 plugins:
   - search
-  - mkdocstrings
+  - mkdocstrings:
+      handlers:
+        python:
+          docstring_style: google
   - markdown-exec
   - macros:
       on_undefined: strict

--- a/pydykit/examples.py
+++ b/pydykit/examples.py
@@ -1,30 +1,71 @@
 from importlib.resources import files
+from typing import Dict, List
 
 from . import utils
 
 
 class ExampleManager:
+    """
+    A manager for handling example files included in the `pydykit` package.
+
+    Provides functionality to load, list, and retrieve example files.
+
+    Attributes:
+        BASE_URL_EXAMPLE_FILES (str): URL pointing to the repository location of the example files.
+        examples (Dict[str, dict]): A dictionary storing the loaded example files with their names as keys.
+    """
 
     BASE_URL_EXAMPLE_FILES = (
         "https://github.com/pydykit/pydykit/tree/main/pydykit/example_files/"
     )
 
     def __init__(self):
-        """TODO: Add docstring"""
+        """
+        Initialize the ExampleManager instance.
+
+        Loads all examples from package resources.
+        """
 
         self.examples = self.load_examples()
 
-    def load_examples(self):
-        """Load content of all examples_files which have been shipped with package pydykit"""
+    def load_examples(self) -> Dict[str, dict]:
+        """
+        Load the content of all example files.
+
+        Example files are expected to be in YAML format and located in the
+        `pydykit/example_files` directory. The content of each file is loaded
+        and stored in a dictionary, where the key is the `name` field specified
+        in the file, and the value is the parsed YAML content.
+
+        Returns:
+            dict: A dictionary containing the loaded example files, keyed by their names.
+        """
         examples = {}
         for path in files("pydykit.example_files").iterdir():
             content = utils.load_yaml_file(path=path)
             examples[content["name"]] = content
         return examples
 
-    def list_examples(self):
-        """List all examples_files which have been shipped with package pydykit"""
+    def list_examples(self) -> List[str]:
+        """
+        List the names of all example files shipped with the `pydykit` package.
+
+        Returns:
+            list: A list of example file names.
+        """
         return list(self.examples.keys())
 
-    def get_example(self, name):
+    def get_example(self, name) -> Dict:
+        """
+        Retrieve the content of a specific example file by its name.
+
+        Args:
+            name (str): The name of the example file to retrieve.
+
+        Returns:
+            dict: The parsed content of the requested example file.
+
+        Raises:
+            KeyError: If the requested example name does not exist in the loaded examples.
+        """
         return self.examples[name]


### PR DESCRIPTION
Actually, I don't think that this makes sense. I think just having the source code without docstrings is nicer, more readable... better.

What do you think @plkinon ?

![image](https://github.com/user-attachments/assets/84b24fc4-fa3e-4844-b2c4-35c08c8e872d)
![image](https://github.com/user-attachments/assets/a1771327-046a-4a95-b7bf-a3a41626f2da)
![image](https://github.com/user-attachments/assets/de4e9492-6bbd-4b79-bbf8-1f6d1daff144)
